### PR TITLE
Improve behavior when handling cards on the NFC interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ def AAVersion = '3.3.2'
 dependencies {
     apt "org.androidannotations:androidannotations:$AAVersion"
     compile "org.androidannotations:androidannotations-api:$AAVersion"
-    compile group: 'com.fidesmo', name: 'nordpol-android', version: '0.1.7', ext: 'aar', transitive: true
+    compile group: 'com.fidesmo', name: 'nordpol-android', version: '0.1.9', ext: 'aar', transitive: true
     compile fileTree(dir: 'libs', include: '*.jar')
     compile "com.android.support:appcompat-v7:23.0.1"
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -2,13 +2,12 @@
 <resources>
 
     <string name="app_name">Counter App</string>
-    <string name="put_card">Please put the card against the back of the phone</string>
+    <string name="put_card_read">Please put the card against the back of the phone to read counter</string>
+    <string name="put_card_decrease">Please put the card against the back of the phone to decrease counter</string>
     <string name="current_counter">The current value of the counter is:</string>
     <string name="reading_card">Reading card...</string>
-    <string name="cardlet_not_installed">It seems that Counter Applet is not installed on the card.\nDo you want to install it?</string>
     <string name="read_counter_button">Read\nCounter</string>
     <string name="decrease_counter_button">Decrease\nCounter</string>
-    <string name="install_app_message">You need to install the Fidesmo App on your phone</string>
     <string name="enable_nfc">Please go to your phone settings and turn on NFC</string>
     <string name="quit">Quit</string>
     <string name="failure">Counter Applet installation failed</string>


### PR DESCRIPTION
- Use Nordpol's TagArbiter to get hold of the tag
- Allow several operations to the card without having to tap the phone several times
- Keep control of the NFC interface in the app as long as it has focus
